### PR TITLE
fix: exclude Postgres partition children from introspection

### DIFF
--- a/src/introspection/postgres-introspection.ts
+++ b/src/introspection/postgres-introspection.ts
@@ -20,6 +20,9 @@ export class PostgresIntrospection extends Introspection {
     private knex: Knex;
     protected logLevel: LogLevel;
 
+    /** Cached set of partition child table names for this schema */
+    private _partitionChildren: Set<string> | null = null;
+
     public constructor(params: { knex: Knex; schemaName?: string; logLevel: LogLevel }) {
         super();
         const { knex, schemaName, logLevel } = params;
@@ -27,6 +30,23 @@ export class PostgresIntrospection extends Introspection {
         if (schemaName) this.schemaName = schemaName;
         else this.schemaName = 'public';
         this.logLevel = logLevel;
+    }
+
+    private async getPartitionChildren(): Promise<Set<string>> {
+        if (this._partitionChildren) return this._partitionChildren;
+
+        type RowType = { child_table: string };
+
+        const rows: RowType[] = await this.query(
+            this.knex('pg_inherits')
+                .join('pg_class as child', 'pg_inherits.inhrelid', '=', 'child.oid')
+                .join('pg_namespace as ns', 'child.relnamespace', '=', 'ns.oid')
+                .where({ 'ns.nspname': this.schemaName })
+                .select('child.relname as child_table'),
+        );
+
+        this._partitionChildren = new Set(rows.map((r) => r.child_table));
+        return this._partitionChildren;
     }
 
     public getTsTypeForColumn(
@@ -302,6 +322,8 @@ export class PostgresIntrospection extends Introspection {
                 .orderBy('c.constraint_name', 'x.ordinal_position'),
         );
 
+        const partitionChildren = await this.getPartitionChildren();
+
         const results: TableMap<RelationDefinition[]> = {};
 
         this.tableMap(rows, (table, rows) => {
@@ -310,6 +332,7 @@ export class PostgresIntrospection extends Introspection {
             rows.forEach((row) => {
                 const { column_name, referenced_table_name, referenced_column_name, constraint_name } = row;
                 if (referenced_table_name == null || referenced_column_name == null) return;
+                if (partitionChildren.has(referenced_table_name)) return;
 
                 if (!relations[constraint_name])
                     relations[constraint_name] = {
@@ -319,10 +342,11 @@ export class PostgresIntrospection extends Introspection {
                         constraintName: constraint_name,
                         type: 'belongsTo', // default always N - 1
                     };
-                relations[constraint_name].joins.push({
-                    fromColumn: column_name,
-                    toColumn: referenced_column_name,
-                });
+                const joins = relations[constraint_name].joins;
+                // Deduplicate: partition children cause repeated join rows.
+                if (!joins.some((j) => j.fromColumn === column_name && j.toColumn === referenced_column_name)) {
+                    joins.push({ fromColumn: column_name, toColumn: referenced_column_name });
+                }
             });
             results[table] = Object.values(relations);
         });
@@ -367,6 +391,8 @@ export class PostgresIntrospection extends Introspection {
                 .orderBy('c.constraint_name', 'x.ordinal_position'),
         );
 
+        const partitionChildren = await this.getPartitionChildren();
+
         const results: TableMap<RelationDefinition[]> = {};
 
         this.tableMap(rows, (table, rows) => {
@@ -381,6 +407,7 @@ export class PostgresIntrospection extends Introspection {
                     table_name,
                 } = row;
                 if (table_name == null || referenced_column_name == null) return;
+                if (partitionChildren.has(referencing_table_name)) return;
 
                 if (!relations[constraint_name])
                     relations[constraint_name] = {
@@ -390,10 +417,11 @@ export class PostgresIntrospection extends Introspection {
                         constraintName: constraint_name,
                         type: 'hasMany', // default always 1 - N
                     };
-                relations[constraint_name].joins.push({
-                    fromColumn: referenced_column_name,
-                    toColumn: referencing_column_name,
-                });
+                const joins = relations[constraint_name].joins;
+                // Deduplicate: partition children cause repeated join rows.
+                if (!joins.some((j) => j.fromColumn === referenced_column_name && j.toColumn === referencing_column_name)) {
+                    joins.push({ fromColumn: referenced_column_name, toColumn: referencing_column_name });
+                }
             });
             results[table] = Object.values(relations);
         });
@@ -413,6 +441,10 @@ export class PostgresIntrospection extends Introspection {
                 .groupBy('table_name'),
         );
 
-        return schemaTables.map((schemaItem: { table_name: string }) => schemaItem.table_name);
+        const partitionChildren = await this.getPartitionChildren();
+
+        return schemaTables
+            .map((schemaItem: { table_name: string }) => schemaItem.table_name)
+            .filter((name: string) => !partitionChildren.has(name));
     }
 }

--- a/test/helpers/migrate-db.ts
+++ b/test/helpers/migrate-db.ts
@@ -3,6 +3,10 @@ import { Knex } from 'knex';
 export const migrateDb = async (knex: Knex, pg = false) => {
     console.info(`Building db schema for ${pg ? 'pg' : 'mysql'}`);
 
+    if (pg) {
+        // Drop partitioned table and children first
+        await knex.raw(`DROP TABLE IF EXISTS events CASCADE`);
+    }
     await knex.schema.dropTableIfExists('team_members_positions');
     await knex.schema.dropTableIfExists('team_members');
     await knex.schema.dropTableIfExists('teams');
@@ -109,4 +113,31 @@ export const migrateDb = async (knex: Knex, pg = false) => {
         table.primary(['team_id', 'user_id']);
         table.foreign(['team_id', 'user_id']).references(['team_id', 'user_id']).inTable('team_members');
     });
+
+    // Partitioned table with FK to users (Postgres-only)
+    // Tests that partition children are excluded from introspection
+    if (pg) {
+        await knex.raw(`
+            CREATE TABLE events (
+                event_id SERIAL,
+                user_id INTEGER NOT NULL,
+                occurred_at TIMESTAMPTZ NOT NULL,
+                payload JSONB,
+                CONSTRAINT fk_events_users FOREIGN KEY (user_id) REFERENCES users (user_id)
+            ) PARTITION BY RANGE (occurred_at);
+        `);
+        // Create three partition children
+        await knex.raw(`
+            CREATE TABLE events_p202501 PARTITION OF events
+                FOR VALUES FROM ('2025-01-01') TO ('2025-02-01');
+        `);
+        await knex.raw(`
+            CREATE TABLE events_p202502 PARTITION OF events
+                FOR VALUES FROM ('2025-02-01') TO ('2025-03-01');
+        `);
+        await knex.raw(`
+            CREATE TABLE events_p202503 PARTITION OF events
+                FOR VALUES FROM ('2025-03-01') TO ('2025-04-01');
+        `);
+    }
 };

--- a/test/introspection/postgres-introspection.test.ts
+++ b/test/introspection/postgres-introspection.test.ts
@@ -1,7 +1,7 @@
 import 'jest-extended';
 import { PostgresIntrospection } from 'src/introspection';
 import { Introspection } from 'src/introspection/introspection';
-import { LogLevel } from 'src/types';
+import { LogLevel, RelationDefinition } from 'src/types';
 import { closeConnection, DB, describeif, knex, openConnection } from 'test/helpers';
 
 describeif(DB() === 'pg')('PostgresIntrospection', () => {
@@ -19,8 +19,23 @@ describeif(DB() === 'pg')('PostgresIntrospection', () => {
     describe('getSchemaTables', () => {
         it('Loads all tables in a schema', async (): Promise<void> => {
             const tables = await intro.getSchemaTables();
-            expect(tables).toHaveLength(5);
-            expect(tables).toIncludeAllMembers(['users', 'teams', 'team_members', 'posts', 'team_members_positions']);
+            expect(tables).toHaveLength(6);
+            expect(tables).toIncludeAllMembers([
+                'users',
+                'teams',
+                'team_members',
+                'posts',
+                'team_members_positions',
+                'events',
+            ]);
+        });
+        it('Excludes partition children from table list', async (): Promise<void> => {
+            const tables = await intro.getSchemaTables();
+            expect(tables).not.toIncludeAnyMembers([
+                'events_p202501',
+                'events_p202502',
+                'events_p202503',
+            ]);
         });
     });
     describe('getEnumTypesForTable', () => {
@@ -261,6 +276,28 @@ describeif(DB() === 'pg')('PostgresIntrospection', () => {
                 }),
             ]);
         });
+        it('Points forward relation toTable to the parent table, not partition children', async (): Promise<void> => {
+            const { events } = await intro.getForwardRelations(['events']);
+            expect(events).toHaveLength(1);
+            expect(events).toIncludeAllMembers([
+                expect.objectContaining({
+                    toTable: 'users',
+                    joins: [
+                        {
+                            fromColumn: 'user_id',
+                            toColumn: 'user_id',
+                        },
+                    ],
+                    type: 'belongsTo',
+                }),
+            ]);
+        });
+        it('Does not produce duplicate joins from partition children', async (): Promise<void> => {
+            const { events } = await intro.getForwardRelations(['events']);
+            const fkRelation = events.find((r: RelationDefinition) => r.toTable === 'users');
+            expect(fkRelation).toBeDefined();
+            expect(fkRelation!.joins).toHaveLength(1);
+        });
     });
     describe('getBackwardRelations', () => {
         it('Loads all relations on foreign keys referencing the table', async (): Promise<void> => {
@@ -348,6 +385,39 @@ describeif(DB() === 'pg')('PostgresIntrospection', () => {
                     ],
                 }),
             ]);
+        });
+        it('Points backward relation to parent table, not partition children', async (): Promise<void> => {
+            const { users } = await intro.getBackwardRelations(['users', 'events']);
+            const eventsRelations = users.filter((r: RelationDefinition) => r.toTable === 'events');
+            expect(eventsRelations).toHaveLength(1);
+            expect(eventsRelations).toIncludeAllMembers([
+                expect.objectContaining({
+                    toTable: 'events',
+                    joins: [
+                        {
+                            fromColumn: 'user_id',
+                            toColumn: 'user_id',
+                        },
+                    ],
+                    type: 'hasMany',
+                }),
+            ]);
+        });
+        it('Does not produce backward relations from partition children', async (): Promise<void> => {
+            const { users } = await intro.getBackwardRelations(['users', 'events']);
+            const partitionRelations = users.filter(
+                (r: RelationDefinition) =>
+                    r.toTable === 'events_p202501' ||
+                    r.toTable === 'events_p202502' ||
+                    r.toTable === 'events_p202503',
+            );
+            expect(partitionRelations).toHaveLength(0);
+        });
+        it('Does not produce duplicate backward joins from partition children', async (): Promise<void> => {
+            const { users } = await intro.getBackwardRelations(['users', 'events']);
+            const eventsRelation = users.find((r: RelationDefinition) => r.toTable === 'events');
+            expect(eventsRelation).toBeDefined();
+            expect(eventsRelation!.joins).toHaveLength(1);
         });
     });
 });


### PR DESCRIPTION
## Summary

- Partition child tables (created by Postgres declarative partitioning) are now automatically excluded from `getSchemaTables()`, `getForwardRelations()`, and `getBackwardRelations()`
- Fixes non-deterministic `toTable` values and duplicate join entries caused by `information_schema.referential_constraints` returning rows for every inherited FK constraint on partition children
- Adds a cached `getPartitionChildren()` method that queries `pg_inherits` to identify child tables

## Problem

When a table uses `PARTITION BY RANGE`, Postgres creates child tables that inherit FK constraints from the parent. The `information_schema` views expose these as separate entries sharing the same `constraint_name`, which causes:

1. **`getSchemaTables`** returns partition children as standalone tables
2. **`getForwardRelations`** picks a non-deterministic partition child as `toTable` instead of the parent
3. **`getBackwardRelations`** creates separate relation entries for each partition child
4. Both relation methods produce duplicate join entries from the query fan-out

## Test coverage

- Added a partitioned `events` table with 3 children and an FK to `users` in the test seed
- 7 new test cases covering all three affected methods